### PR TITLE
Fix emoji prefix for issue names

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.md
+++ b/.github/ISSUE_TEMPLATE/bug-report.md
@@ -1,5 +1,5 @@
 ---
-name: '\U0001F41B Bug report'
+name: "\U0001F41B Bug report"
 about: File a report to help us reproduce and fix the problem
 title: ''
 labels: 'bug'

--- a/.github/ISSUE_TEMPLATE/documentation-improvement.md
+++ b/.github/ISSUE_TEMPLATE/documentation-improvement.md
@@ -1,5 +1,5 @@
 ---
-name: '\U0001F4DA Documentation improvement'
+name: "\U0001F4DA Documentation improvement"
 about: Request improved documentation
 title: ''
 labels: 'docs'

--- a/.github/ISSUE_TEMPLATE/feature-request.md
+++ b/.github/ISSUE_TEMPLATE/feature-request.md
@@ -1,5 +1,5 @@
 ---
-name: '\U0001F680 Feature request'
+name: "\U0001F680 Feature request"
 about: Suggest new functionality for this library
 title: ''
 labels: 'enhancement'


### PR DESCRIPTION
*Issue #, if available:* NA

*Description of changes:* Fix the prefix for the issue template so that the emoji/icon actually shows up now.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
