### PR TITLE
Added screening notebook for pyspark ON sagemaker notebook instance

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -137,3 +137,8 @@ venv.bak/
 .project
 .pydevproject
 .settings
+
+# pyspark
+derby.log
+metastore_db
+spark-warehouse

--- a/notebooks/screening/screen-pyspark-smnb.ipynb
+++ b/notebooks/screening/screen-pyspark-smnb.ipynb
@@ -1,0 +1,155 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "described-peter",
+   "metadata": {},
+   "source": [
+    "This notebook screens that it can run pyspark on a SageMaker notebook instance. This is **NOT** intended to screen a PySpark processing job. It is designed to run in one go without a kernel restart, hence run only a short PySpark operation.\n",
+    "\n",
+    "Steps:\n",
+    "\n",
+    "- **Pre-requisite**: make sure to choose kernel `conda_python3`\n",
+    "- **Action**: click *Kernel* -> *Restart Kernel and Run All Cells...*\n",
+    "- **Expected outcome**: no exception seen."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "polar-threshold",
+   "metadata": {},
+   "source": [
+    "# Setup\n",
+    "\n",
+    "Before you run the next cell, please open `smconfig.py` and review+update the `s3_bucket` variable, then disable the `NotImplementedException` in the last line."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "extreme-japanese",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%load_ext autoreload\n",
+    "%autoreload 2\n",
+    "\n",
+    "import os\n",
+    "import pandas as pd\n",
+    "import sagemaker_pyspark\n",
+    "from pyspark import SparkContext, SparkConf\n",
+    "from pyspark.sql import SparkSession\n",
+    "\n",
+    "import smconfig\n",
+    "\n",
+    "# Configuration of this screening test\n",
+    "testfile = 'testfile.snappy.parquet'\n",
+    "s3_path = f'{smconfig.s3_bucket}/screening/pyspark-on-smnb/{testfile}'\n",
+    "s3a_path = 's3a' + s3_path[2:]\n",
+    "\n",
+    "# Propagate to env vars of the whole notebook, for usage by ! or %%.\n",
+    "%set_env S3_PATH=$s3_path\n",
+    "%set_env TESTFILE=$testfile"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "distinct-guide",
+   "metadata": {},
+   "source": [
+    "# PySpark on this SageMaker notebook instance"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "racial-retention",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "df = pd.DataFrame({'a': [1,2,3,4,5], 'b': [10,20,30,40,50]})\n",
+    "df.to_parquet(f'/tmp/{testfile}', compression='snappy')\n",
+    "!aws s3 cp /tmp/$TESTFILE $S3_PATH --storage-class ONEZONE_IA\n",
+    "\n",
+    "classpath = \":\".join(sagemaker_pyspark.classpath_jars())\n",
+    "spark = (\n",
+    "    SparkSession\n",
+    "    .builder\n",
+    "    .config(\"spark.driver.extraClassPath\", classpath)\n",
+    "    .master(\"local[*]\").getOrCreate()\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "printable-nickname",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "DataFrame[a: bigint, b: bigint]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "DataFrame[a: bigint, b: bigint]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "DataFrame[a: bigint, b: bigint]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "display(\n",
+    "    spark.read.load(f'/tmp/{testfile}'),\n",
+    "    spark.read.load(s3a_path),\n",
+    "    spark.read.parquet(s3a_path),\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "recent-thinking",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "conda_python3",
+   "language": "python",
+   "name": "conda_python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.6.13"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:* added a notebook to screen the ability to run pyspark directly on the notebook instance itself (normally for interactive EDA on a subset of partitions). This is **not** to screen processing jobs or EMR. 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
