### PR TITLE
Flake8 fix

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,13 +10,11 @@ repos:
   rev: 19.10b0
   hooks:
   - id: black
-    args: ["-l 88"]
 - repo: https://gitlab.com/pycqa/flake8
   rev: 3.7.9
   hooks:
   - id: flake8
-    args: ["--max-complexity=20", "--ignore=E231, W503, E722, E231", "--max-line-length=88"]
 - repo: https://github.com/timothycrosley/isort
   rev: 5.7.0
-  hooks: 
+  hooks:
   - id: isort

--- a/tox.ini
+++ b/tox.ini
@@ -19,6 +19,7 @@ envlist = flake8,isort-check,black-check,pytest
 
 [flake8]
 max-complexity = 20
+max-line-length = 88
 exclude =
     build/
     .git
@@ -30,6 +31,7 @@ exclude =
     venv/
     .venv/
 ignore = E203, W503, E722, E231
+per-file-ignores = __init__.py:F401
 
 [isort]
 atomic = True


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:* improved linter configurations.

- do not apply unused import on `__init__.py`, otherwise flake8 raises false positive when `__init__.py` exports select symbols
- deduplicated linters settings from pre-commit. Instead, linters will source their config from `tox.ini` and `pyproject.toml`.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
