### PR TITLE
fix broken stepfunction compatibilities

### DIFF
--- a/modules/data/requirements.txt
+++ b/modules/data/requirements.txt
@@ -1,7 +1,7 @@
 sagemaker<2.0.0,>=1.71.0
 boto3>=1.9.213
 pyyaml
-stepfunctions>=1.1.0
+stepfunctions>=1.1.0,<2.0.0
 fsspec
 s3fs
 scikit-learn==0.20.0

--- a/modules/pipeline/requirements.txt
+++ b/modules/pipeline/requirements.txt
@@ -1,7 +1,7 @@
 sagemaker>=1.71.0,<2.0.0
 boto3>=1.9.213
 pyyaml
-stepfunctions>=1.1.0
+stepfunctions>=1.1.0,<2.0.0
 fsspec
 s3fs
 scikit-learn==0.20.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 sagemaker>=1.71.0,<2.0.0
 boto3>=1.9.213
 pyyaml
-stepfunctions>=1.1.0
+stepfunctions>=1.1.0,<2.0.0
 fsspec
 s3fs
 scikit-learn==0.20.0


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:* 

A default `pip install -r requirements.txt` with the current `requirements.txt` files result in the installation of `stepfunctions-2.1.0` (at the time of writing). 

This version of `stepfunctions` is not compatible with the version of `sagemaker` specified, with this error message being given on installation:

`ERROR: stepfunctions 2.1.0 has requirement sagemaker>=2.1.0, but you'll have sagemaker 1.72.1 which is incompatible.`

This will cause errors in at least `pipeline` module - for example:

```bash
(venv) 88665a1f1803:pipeline jggoyder$ python training_pipeline_create.py 
Traceback (most recent call last):
  File "training_pipeline_create.py", line 1, in <module>
    from training_pipeline_define import define_training_pipeline
  File "/Users/jggoyder/Projects/mlmax/modules/pipeline/training_pipeline_define.py", line 1, in <module>
    import stepfunctions
  File "/Users/jggoyder/Projects/mlmax/modules/pipeline/venv/lib/python3.7/site-packages/stepfunctions/__init__.py", line 19, in <module>
    __version__ = pkg_resources.require("stepfunctions")[0].version
  File "/Users/jggoyder/Projects/mlmax/modules/pipeline/venv/lib/python3.7/site-packages/pkg_resources/__init__.py", line 901, in require
    needed = self.resolve(parse_requirements(requirements))
  File "/Users/jggoyder/Projects/mlmax/modules/pipeline/venv/lib/python3.7/site-packages/pkg_resources/__init__.py", line 792, in resolve
    raise VersionConflict(dist, req).with_context(dependent_req)
pkg_resources.ContextualVersionConflict: (sagemaker 1.72.1 (/Users/jggoyder/Projects/mlmax/modules/pipeline/venv/lib/python3.7/site-packages), Requirement.parse('sagemaker>=2.1.0'), {'stepfunctions'})
``` 

With the additional `<2.0.0` version constraint on `stepfunctions`, `stepfunctions-1.1.2` is installed instead. The `pipeline` module scripts can be executed successfully.  

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
